### PR TITLE
Add multibranch pipeline config

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -22,7 +22,8 @@ pipeline {
         disableConcurrentBuilds()
     }
     triggers {
-        githubPush()
+        githubPush() // Trigger by push to respective github branch
+        pollSCM 'H/30 * * * *' // Fallback polling solution as some pushes are somehow lost
     } 
     environment {
         GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
                                             \\"state\\": \\"pending\\",
                                             \\"context\\": \\"jenkins-${compiler}-${build_type}-ctest\\",
                                             \\"description\\": \\"Jenkins CI Job: jenkins-${compiler}-${build_type}-ctest\\",
-                                            \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/CPPuddle/$BUILD_NUMBER/console\\"
+                                            \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/CPPuddle/job/${JOB_BASE_NAME}/${BUILD_NUMBER}/console\\"
                                     }"
                                 '''
                             }
@@ -122,7 +122,7 @@ pipeline {
                                     \\"state\\": \\"success\\",
                                     \\"context\\": \\"jenkins-${compiler}-${build_type}-ctest\\",
                                     \\"description\\": \\"Jenkins CI Job: jenkins-${compiler}-${build_type}-ctest\\",
-                                    \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/CPPuddle/$BUILD_NUMBER/console\\"
+                                    \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/CPPuddle/job/${JOB_BASE_NAME}/${BUILD_NUMBER}/console\\"
                             }"
                         '''
                     }
@@ -138,7 +138,7 @@ pipeline {
                                     \\"state\\": \\"failure\\",
                                     \\"context\\": \\"jenkins-${compiler}-${build_type}-ctest\\",
                                     \\"description\\": \\"Jenkins CI Job: jenkins-${compiler}-${build_type}-ctest\\",
-                                    \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/CPPuddle/$BUILD_NUMBER/console\\"
+                                    \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/CPPuddle/job/${JOB_BASE_NAME}/${BUILD_NUMBER}/console\\"
                             }"
                         '''
                     }
@@ -154,7 +154,7 @@ pipeline {
                                     \\"state\\": \\"error\\",
                                     \\"context\\": \\"jenkins-${compiler}-${build_type}-ctest\\",
                                     \\"description\\": \\"Jenkins CI Job: jenkins-${compiler}-${build_type}-ctest\\",
-                                    \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/CPPuddle/$BUILD_NUMBER/console\\"
+                                    \\"target_url\\": \\"https://simsgs.informatik.uni-stuttgart.de/jenkins/job/CPPuddle/job/${JOB_BASE_NAME}/${BUILD_NUMBER}/console\\"
                             }"
                         '''
                     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -6,6 +6,8 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
   return
 }
 
+def buildbadge = addEmbeddableBadgeConfiguration(id: "build-and-test-${env.JOB_BASE_NAME}", subject: "CUDA/Kokkos ctest")
+
 pipeline {
     agent { label 'pcsgs05' }
     options {
@@ -28,6 +30,7 @@ pipeline {
     stages {
         stage('checkout') {
             steps {
+		buildbadge.setStatus('running')
                 dir('CPPuddle') {
                     checkout scm
                     sh '''
@@ -106,6 +109,7 @@ pipeline {
                 }
                 post {
                     success {
+			buildbadge.setStatus('passing')
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\
@@ -122,6 +126,7 @@ pipeline {
                         '''
                     }
                     failure {
+			buildbadge.setStatus('failing')
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\
@@ -138,6 +143,7 @@ pipeline {
                         '''
                     }
                     aborted {
+			buildbadge.setStatus('aborted')
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -1,7 +1,27 @@
 #!groovy
+
+if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
+  print "INFO: Build skipped due being triggered by Branch Indexing instead of SCM change!"
+  currentBuild.result = 'ABORTED' // default would be successful: this makes it more clear that is thas been skipped
+  return
+}
+
 pipeline {
     agent { label 'pcsgs05' }
-
+    options {
+        buildDiscarder(
+            logRotator(
+                daysToKeepStr: "21",
+                numToKeepStr: "50",
+                artifactDaysToKeepStr: "21",
+                artifactNumToKeepStr: "50"
+            )
+        )
+        disableConcurrentBuilds()
+    }
+    triggers {
+        githubPush()
+    } 
     environment {
         GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')
     }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -30,7 +30,9 @@ pipeline {
     stages {
         stage('checkout') {
             steps {
-		buildbadge.setStatus('running')
+                script {
+		    buildbadge.setStatus('running')
+                }
                 dir('CPPuddle') {
                     checkout scm
                     sh '''
@@ -109,7 +111,9 @@ pipeline {
                 }
                 post {
                     success {
-			buildbadge.setStatus('passing')
+			script {
+			    buildbadge.setStatus('passing')
+			}
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\
@@ -126,7 +130,9 @@ pipeline {
                         '''
                     }
                     failure {
-			buildbadge.setStatus('failing')
+			script {
+			    buildbadge.setStatus('failing')
+			}
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\
@@ -143,7 +149,9 @@ pipeline {
                         '''
                     }
                     aborted {
-			buildbadge.setStatus('aborted')
+			script {
+			    buildbadge.setStatus('aborted')
+			}
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -111,9 +111,6 @@ pipeline {
                 }
                 post {
                     success {
-			script {
-			    buildbadge.setStatus('passing')
-			}
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\
@@ -130,9 +127,6 @@ pipeline {
                         '''
                     }
                     failure {
-			script {
-			    buildbadge.setStatus('failing')
-			}
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\
@@ -149,9 +143,6 @@ pipeline {
                         '''
                     }
                     aborted {
-			script {
-			    buildbadge.setStatus('aborted')
-			}
                         sh '''
                             github_token=$(echo ${GITHUB_TOKEN} | cut -f2 -d':')
                             curl --verbose\
@@ -169,6 +160,23 @@ pipeline {
                     }
                 }
             }
+        }
+    }
+    post {
+        success {
+	    script {
+	        buildbadge.setStatus('success')
+	    }
+        }
+        failure {
+	    script {
+	        buildbadge.setStatus('failing')
+	    }
+        }
+        aborted {
+	    script {
+	        buildbadge.setStatus('aborted')
+	    }
         }
     }
 }

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -6,7 +6,7 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
   return
 }
 
-def buildbadge = addEmbeddableBadgeConfiguration(id: "build-and-test-${env.JOB_BASE_NAME}", subject: "CUDA/Kokkos ctest")
+def buildbadge = addEmbeddableBadgeConfiguration(id: "allbuilds", subject: "CUDA/Kokkos ctest", status: "running")
 
 pipeline {
     agent { label 'pcsgs05' }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 WARNING: This repository is a work in progress and should not be relied on for production use!
 
 [![ctests](https://github.com/SC-SGS/CPPuddle/actions/workflows/cmake.yml/badge.svg)](https://github.com/SC-SGS/CPPuddle/actions/workflows/cmake.yml)
-[![Build Status](https://simsgs.informatik.uni-stuttgart.de/jenkins/buildStatus/icon?style=flat&subject=jenkins-ctest&job=CPPuddle)](https://simsgs.informatik.uni-stuttgart.de/jenkins/view/Octo-Tiger%20and%20Dependencies/job/CPPuddle/)
+[![Build Status](https://simsgs.informatik.uni-stuttgart.de/jenkins/view/Octo-Tiger%20and%20Dependencies/job/CPPuddle/job/master/badge/icon?config=allbuilds)](https://simsgs.informatik.uni-stuttgart.de/jenkins/view/Octo-Tiger%20and%20Dependencies/job/CPPuddle/job/master/)
 
 
 #### Purpose

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 WARNING: This repository is a work in progress and should not be relied on for production use!
 
 [![ctests](https://github.com/SC-SGS/CPPuddle/actions/workflows/cmake.yml/badge.svg)](https://github.com/SC-SGS/CPPuddle/actions/workflows/cmake.yml)
-[![Build Status](https://simsgs.informatik.uni-stuttgart.de/jenkins/view/Octo-Tiger%20and%20Dependencies/job/CPPuddle/job/master/badge/icon?config=allbuilds)](https://simsgs.informatik.uni-stuttgart.de/jenkins/view/Octo-Tiger%20and%20Dependencies/job/CPPuddle/job/master/)
+[![Build Status](https://simsgs.informatik.uni-stuttgart.de/jenkins/buildStatus/icon?job=CPPuddle%2Fmaster&config=allbuilds)](https://simsgs.informatik.uni-stuttgart.de/jenkins/view/Octo-Tiger%20and%20Dependencies/job/CPPuddle/job/master/)
 
 
 #### Purpose


### PR DESCRIPTION
This PR adds all the necessary changes to switch from a normal Jenkins pipeline to a multibranch pipeline
- Define all necessary options in the Jenkinsfile as opposed to doing it in the Jenkins UI
- Add early exit condition in case the build is triggered by the branch (re)indexing
- Manually handle to build badge to avoid that is shows builds that are aborted due to aforementioned early exit condition