### PR TITLE
Build via branch indexing only

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -2,39 +2,19 @@
 
 def buildbadge = addEmbeddableBadgeConfiguration(id: "allbuilds", subject: "CUDA/Kokkos ctest", status: "skipped")
 
-// Skip builds that are likely to be tested already (by push) and unlikely to be critical (not on master)
-if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
-    print "INFO: Build on ${env.BRANCH_NAME} triggered by branch indexing..."
-    if (env.BRANCH_NAME != "master") {
-        if (env.BUILD_NUMBER != "1") { // Always run first build on a new branch pipeline to load the options (and thus github hook triggers) for the pipeline
-            print "INFO: Build on ${env.BRANCH_NAME} skipped due being triggered by Branch Indexing instead of SCM change!"
-            buildbadge.setStatus('skipped')
-            currentBuild.result = 'ABORTED' 
-            return
-        }
-    }
-} else {
-    print "INFO: Build on ${env.BRANCH_NAME} triggered by SCM change..."
-    print "Proceeding!"
-} 
-
 pipeline {
     agent { label 'pcsgs05' }
     options {
         buildDiscarder(
             logRotator(
-                daysToKeepStr: "21",
-                numToKeepStr: "50",
-                artifactDaysToKeepStr: "21",
-                artifactNumToKeepStr: "50"
+                daysToKeepStr: "28",
+                numToKeepStr: "100",
+                artifactDaysToKeepStr: "28",
+                artifactNumToKeepStr: "100"
             )
         )
         disableConcurrentBuilds()
     }
-    triggers {
-        githubPush() // Trigger by push to respective github branch
-        pollSCM 'H/30 * * * *' // Fallback polling solution as some pushes are somehow lost
-    } 
     environment {
         GITHUB_TOKEN = credentials('GITHUB_TOKEN_OCTOTIGER')
         MAINTAINER_MAIL = credentials('CPPUDDLE_MAINTAINER_EMAIL')
@@ -51,7 +31,6 @@ pipeline {
                     sh '''
                         git submodule update --init --recursive
                         ./scripts/clean_dependencies.sh
-                        echo "Build started on pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins CPPuddle: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} just started..." "${MAINTAINER_MAIL}"
                     '''
                 }
             }
@@ -181,9 +160,6 @@ pipeline {
 	    script {
 	        buildbadge.setStatus('success')
 	    }
-            sh '''
-                echo "Build succeded! Pipeline ${JOB_BASE_NAME} with build ID ${BUILD_NUMBER} using GIT commit ${GIT_COMMIT}" | mail -s "Jenkins CPPuddle: Build ${JOB_BASE_NAME}/${BUILD_NUMBER} succeded" "${MAINTAINER_MAIL}"
-            '''
         }
         failure {
 	    script {


### PR DESCRIPTION
- Remove jenkins triggers and branch indexing guard
- Make pipeline less verbose (only send mails on failures)
- Keep logs for a longer time