### PR TITLE
Add sycl allocators

### DIFF
--- a/include/hip_buffer_util.hpp
+++ b/include/hip_buffer_util.hpp
@@ -3,8 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef CUDA_BUFFER_UTIL_HPP
-#define CUDA_BUFFER_UTIL_HPP
+#ifndef HIP_BUFFER_UTIL_HPP
+#define HIP_BUFFER_UTIL_HPP
 
 #include "buffer_manager.hpp"
 

--- a/include/sycl_buffer_util.hpp
+++ b/include/sycl_buffer_util.hpp
@@ -1,0 +1,73 @@
+// Copyright (c: 2020-2021 Gregor Daiß
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef SYCL_BUFFER_UTIL_HPP
+#define SYCL_BUFFER_UTIL_HPP
+
+#include "buffer_manager.hpp"
+
+#include <CL/sycl.hpp>
+#include <stdexcept>
+#include <string>
+
+namespace recycler {
+
+namespace detail {
+
+template <class T> struct sycl_pinned_default_allocator {
+  using value_type = T;
+  sycl_pinned_default_allocator() noexcept = default;
+  template <class U>
+  explicit sycl_pinned_default_allocator(sycl_pinned_default_allocator<U> const &) noexcept {}
+  T *allocate(std::size_t n) {
+    static cl::sycl::queue default_queue(cl::sycl::default_selector{});
+    T *data = cl::sycl::malloc_host<T>(n, default_queue);
+    return data;
+  }
+  void deallocate(T *p, std::size_t n) {
+    static cl::sycl::queue default_queue(cl::sycl::default_selector{});
+    cl::sycl::free(p, default_queue);
+  }
+};
+template <class T, class U>
+constexpr bool operator==(sycl_pinned_default_allocator<T> const &,
+                          sycl_pinned_default_allocator<U> const &) noexcept {
+  return true;
+}
+template <class T, class U>
+constexpr bool operator!=(sycl_pinned_default_allocator<T> const &,
+                          sycl_pinned_default_allocator<U> const &) noexcept {
+  return false;
+}
+
+template <class T> struct sycl_device_default_allocator {
+  using value_type = T;
+  sycl_device_default_allocator() noexcept = default;
+  template <class U>
+  explicit sycl_device_default_allocator(sycl_device_default_allocator<U> const &) noexcept {}
+  T *allocate(std::size_t n) {
+    static cl::sycl::queue default_queue(cl::sycl::default_selector{});
+    T *data = cl::sycl::malloc_device<T>(n, default_queue);
+    return data;
+  }
+  void deallocate(T *p, std::size_t n) {
+    static cl::sycl::queue default_queue(cl::sycl::default_selector{});
+    cl::sycl::free(p, default_queue);
+  }
+};
+template <class T, class U>
+constexpr bool operator==(sycl_device_default_allocator<T> const &,
+                          sycl_device_default_allocator<U> const &) noexcept {
+  return true;
+}
+template <class T, class U>
+constexpr bool operator!=(sycl_device_default_allocator<T> const &,
+                          sycl_device_default_allocator<U> const &) noexcept {
+  return false;
+}
+
+} // end namespace detail
+} // end namespace recycler
+#endif

--- a/include/sycl_buffer_util.hpp
+++ b/include/sycl_buffer_util.hpp
@@ -16,11 +16,11 @@ namespace recycler {
 
 namespace detail {
 
-template <class T> struct sycl_pinned_default_allocator {
+template <class T> struct sycl_host_default_allocator {
   using value_type = T;
-  sycl_pinned_default_allocator() noexcept = default;
+  sycl_host_default_allocator() noexcept = default;
   template <class U>
-  explicit sycl_pinned_default_allocator(sycl_pinned_default_allocator<U> const &) noexcept {}
+  explicit sycl_host_default_allocator(sycl_host_default_allocator<U> const &) noexcept {}
   T *allocate(std::size_t n) {
     static cl::sycl::queue default_queue(cl::sycl::default_selector{});
     T *data = cl::sycl::malloc_host<T>(n, default_queue);
@@ -32,13 +32,13 @@ template <class T> struct sycl_pinned_default_allocator {
   }
 };
 template <class T, class U>
-constexpr bool operator==(sycl_pinned_default_allocator<T> const &,
-                          sycl_pinned_default_allocator<U> const &) noexcept {
+constexpr bool operator==(sycl_host_default_allocator<T> const &,
+                          sycl_host_default_allocator<U> const &) noexcept {
   return true;
 }
 template <class T, class U>
-constexpr bool operator!=(sycl_pinned_default_allocator<T> const &,
-                          sycl_pinned_default_allocator<U> const &) noexcept {
+constexpr bool operator!=(sycl_host_default_allocator<T> const &,
+                          sycl_host_default_allocator<U> const &) noexcept {
   return false;
 }
 
@@ -67,6 +67,13 @@ constexpr bool operator!=(sycl_device_default_allocator<T> const &,
                           sycl_device_default_allocator<U> const &) noexcept {
   return false;
 }
+
+template <typename T, std::enable_if_t<std::is_trivial<T>::value, int> = 0>
+using recycle_allocator_sycl_host =
+    detail::aggressive_recycle_allocator<T, detail::sycl_host_default_allocator<T>>;
+template <typename T, std::enable_if_t<std::is_trivial<T>::value, int> = 0>
+using recycle_allocator_sycl_device =
+    detail::recycle_allocator<T, detail::sycl_device_default_allocator<T>>;
 
 } // end namespace detail
 } // end namespace recycler

--- a/include/sycl_buffer_util.hpp
+++ b/include/sycl_buffer_util.hpp
@@ -68,6 +68,8 @@ constexpr bool operator!=(sycl_device_default_allocator<T> const &,
   return false;
 }
 
+} // end namespace detail
+
 template <typename T, std::enable_if_t<std::is_trivial<T>::value, int> = 0>
 using recycle_allocator_sycl_host =
     detail::aggressive_recycle_allocator<T, detail::sycl_host_default_allocator<T>>;
@@ -75,6 +77,5 @@ template <typename T, std::enable_if_t<std::is_trivial<T>::value, int> = 0>
 using recycle_allocator_sycl_device =
     detail::recycle_allocator<T, detail::sycl_device_default_allocator<T>>;
 
-} // end namespace detail
 } // end namespace recycler
 #endif


### PR DESCRIPTION
This PR adds SYCL allocators for convenience with SYCL builds. The allocators themselves use a status SYCL internally and thus do not need to be passed one. This allows them to be used together with the existing pool interface inside CPPuddle (enabling a quick integration into Octo-Tiger for testing without further changes). The interface might be extended in the future if required to also allow for external SYCL queues/devices to be passed to the allocators.

Depends on #14 , hence I'm adding it as a draft PR for now.