### PR TITLE
Fix combined CPU GPU execution

### DIFF
--- a/include/stream_manager.hpp
+++ b/include/stream_manager.hpp
@@ -315,6 +315,10 @@ public:
     return interface.async_execute(std::forward<F>(f), std::forward<Ts>(ts)...);
   }
 
+  inline decltype(auto) get_future() {
+    return interface.get_future();
+  }
+
   // allow implict conversion
   operator Interface &() { // NOLINT
     return interface;


### PR DESCRIPTION
This PR fixes the usage reference counting within work aggregation areas. Notably, this allows for combined CPU+GPU execution once more, as the basic CPU/GPU load balancing relied on this referencing counting to judge whether to run a kernel on the GPU or CPU.