### PR TITLE
Remove erroneous assert

### DIFF
--- a/include/aggregation_manager.hpp
+++ b/include/aggregation_manager.hpp
@@ -11,7 +11,7 @@
 #endif
 
 #include <stdexcept>
-#define DEBUG_AGGREGATION_CALLS 1
+//#define DEBUG_AGGREGATION_CALLS 1
 
 #include <stdio.h>
 

--- a/include/stream_manager.hpp
+++ b/include/stream_manager.hpp
@@ -265,7 +265,6 @@ private:
 
     static void set_device_selector(std::function<void(size_t)> select_gpu_function) {
       auto guard = make_scoped_lock_from_array(instance().gpu_mutexes);
-      assert(instance().streampools.size() == recycler::max_number_gpus);
       instance().select_gpu_function = select_gpu_function;
     }
 


### PR DESCRIPTION
This PR removes a troublesome assert that was simply not correct. It also deactivates the over-the-top aggregation checks in debug builds (can still be reactivated if ever required).