### PR TITLE
Add aggregation region wrapper

### DIFF
--- a/include/cppuddle/common/config.hpp
+++ b/include/cppuddle/common/config.hpp
@@ -53,9 +53,7 @@ constexpr size_t max_number_gpus = CPPUDDLE_HAVE_MAX_NUMBER_GPUS;
 #ifndef CPPUDDLE_HAVE_HPX
 static_assert(max_number_gpus == 1, "Non HPX builds do not support multigpu");
 #endif
-//static_assert(number_instances >= max_number_gpus);
 static_assert(max_number_gpus > 0);
-//constexpr size_t instances_per_gpu = number_instances / max_number_gpus;
 
 /// Uses HPX thread information to determine which GPU should be used
 inline size_t get_device_id(const size_t number_gpus) {

--- a/include/cppuddle/kernel_aggregation/detail/aggregation_executor_pools.hpp
+++ b/include/cppuddle/kernel_aggregation/detail/aggregation_executor_pools.hpp
@@ -50,7 +50,7 @@ public:
   static decltype(auto) request_executor_slice(void) {
     if (!is_initialized) {
       throw std::runtime_error(
-          std::string("Trying to use cppuddle aggregation pool without first calling init") +
+          std::string("ERROR: Trying to use cppuddle aggregation pool without first calling init!\n") +
           " Agg poolname: " + std::string(kernelname));
     }
     const size_t gpu_id = cppuddle::get_device_id(number_devices);
@@ -126,6 +126,20 @@ public:
   aggregation_pool(aggregation_pool &&other) = delete;
   aggregation_pool &operator=(aggregation_pool &&other) = delete;
 };
+
+template <typename aggregation_region_t>
+void init_area_aggregation_pool(
+    const size_t max_slices) {
+    constexpr size_t number_aggregation_executors = 128;
+    constexpr size_t number_gpus = cppuddle::max_number_gpus;
+    aggregated_executor_modes executor_mode = aggregated_executor_modes::EAGER;
+    if (max_slices == 1) {
+      executor_mode = aggregated_executor_modes::STRICT;
+    }
+    aggregation_region_t::init(
+        number_aggregation_executors, max_slices, executor_mode, number_gpus);
+}
+
 
 } // namespace detail
 } // namespace kernel_aggregation

--- a/include/cppuddle/kernel_aggregation/kernel_aggregation_interface.hpp
+++ b/include/cppuddle/kernel_aggregation/kernel_aggregation_interface.hpp
@@ -56,12 +56,15 @@ hpx::future<return_type> aggregation_region(const size_t team_size,
     hpx::call_once(pool_init,
         detail::init_area_aggregation_pool<aggregation_pool_t>, team_size);
     auto executor_slice_fut = aggregation_pool_t::request_executor_slice();
-    auto ret_fut = executor_slice_fut.value().then(hpx::annotated_function([aggregation_area](auto && fut) {
-      typename cppuddle::kernel_aggregation::detail::aggregated_executor<executor_t>::Executor_Slice agg_exec = fut.get();
-      const size_t slice_id = agg_exec.id;
-      const size_t number_slices = agg_exec.number_slices;
-      return aggregation_area(slice_id, number_slices, agg_exec);
-    }, region_name));
+    auto ret_fut = executor_slice_fut.value().then(hpx::annotated_function(
+        [aggregation_area](auto &&fut) {
+          typename cppuddle::kernel_aggregation::detail::aggregated_executor<
+              executor_t>::Executor_Slice agg_exec = fut.get();
+          const size_t slice_id = agg_exec.id;
+          const size_t number_slices = agg_exec.number_slices;
+          return aggregation_area(slice_id, number_slices, agg_exec);
+        },
+        region_name));
     return ret_fut;
 }
 


### PR DESCRIPTION
Using an aggregation region for the explicit work aggregation kernel fusion was a bit of a hassle previously: One had to pick a name, initialize the pool, obtain a future for an aggregation executor and lastly launch the aggregation as an continuation of that future.

This PR streamlines this process: The user now only has to user the aggregation_region wrapper that does all of the above automatically!