### PR TITLE
Update aggregation_executors_and_allocators.hpp to compile with gcc 14

### DIFF
--- a/include/cppuddle/kernel_aggregation/detail/aggregation_executors_and_allocators.hpp
+++ b/include/cppuddle/kernel_aggregation/detail/aggregation_executors_and_allocators.hpp
@@ -394,7 +394,7 @@ class allocator_slice;
 template <typename Executor> class aggregated_executor {
 private:
   //===============================================================================
-  // Misc private avariables:
+  // Misc private variables:
   //
   std::atomic<bool> slices_exhausted;
 
@@ -432,8 +432,8 @@ public:
     /// How many slices are there overall - required to check the launch
     /// criteria
     const size_t number_slices;
-    const size_t max_slices;
-    const size_t id;
+    size_t max_slices;
+    size_t id;
     using executor_t = Executor;
     executor_slice(aggregated_executor &parent, const size_t slice_id,
                    const size_t number_slices, const size_t max_number_slices)


### PR DESCRIPTION
Using GCC 14 we get the following error message:

```
    '/home/pdiehl/spack/opt/spack/linux-fedora40-skylake_avx512/gcc-14.0.1/gmake-4.4.1-jhgb7givzvmwu5zaptjc443eqril2chf/bin/make' '-j8'

5 errors found in build log:
     428    /usr/include/c++/14/pstl/algorithm_impl.h:3390:5: note: '#pragma message:  [Parallel STL message]: "Vectorized algorithm uni
            mplemented, redirected to serial"'
     429     3390 |     _PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
     430          |     ^~~~~~~~~~~~~~~~~~~~
     431    In file included from /tmp/pdiehl/spack-stage/spack-stage-octotiger-master-xtouwogmsu4ac7ttolute2ot7mzs46od/spack-src/octoti
            ger/unitiger/hydro_impl/hydro_kokkos_kernel.hpp:11,
     432                     from /tmp/pdiehl/spack-stage/spack-stage-octotiger-master-xtouwogmsu4ac7ttolute2ot7mzs46od/spack-src/src/un
            itiger/hydro_impl/hydro_kernel_interface.cpp:16:
     433    /home/pdiehl/spack/opt/spack/linux-fedora40-skylake_avx512/gcc-14.0.1/cppuddle-0.3.1-lrj54bmcsximnerirrwtn2jdrmk4g6yj/includ
            e/aggregation_manager.hpp: In member function 'Aggregated_Executor<Executor>::Executor_Slice& Aggregated_Executor<Executor>:
            :Executor_Slice::operator=(Aggregated_Executor<Executor>::Executor_Slice&&)':
  >> 434    /home/pdiehl/spack/opt/spack/linux-fedora40-skylake_avx512/gcc-14.0.1/cppuddle-0.3.1-lrj54bmcsximnerirrwtn2jdrmk4g6yj/includ
            e/aggregation_manager.hpp:463:21: error: assignment of read-only member 'Aggregated_Executor<Executor>::Executor_Slice::numb
            er_slices'
     435      463 |       number_slices = std::move(other.number_slices);
     436          |       ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  >> 437    /home/pdiehl/spack/opt/spack/linux-fedora40-skylake_avx512/gcc-14.0.1/cppuddle-0.3.1-lrj54bmcsximnerirrwtn2jdrmk4g6yj/includ
            e/aggregation_manager.hpp:464:10: error: assignment of read-only member 'Aggregated_Executor<Executor>::Executor_Slice::id'
     438      464 |       id = std::move(other.id);
     439          |       ~~~^~~~~~~~~~~~~~~~~~~~~
  >> 440    make[2]: *** [CMakeFiles/hydrolib.dir/build.make:93: CMakeFiles/hydrolib.dir/src/unitiger/hydro_impl/hydro_kernel_interface.
            cpp.o] Error 1
     441    make[2]: Leaving directory '/tmp/pdiehl/spack-stage/spack-stage-octotiger-master-xtouwogmsu4ac7ttolute2ot7mzs46od/spack-src/
            spack-build'
  >> 442    make[1]: *** [CMakeFiles/Makefile2:194: CMakeFiles/hydrolib.dir/all] Error 2
     443    make[1]: Leaving directory '/tmp/pdiehl/spack-stage/spack-stage-octotiger-master-xtouwogmsu4ac7ttolute2ot7mzs46od/spack-src/
            spack-build'
  >> 444    make: *** [Makefile:139: all] Error 2
```

This gets fixed by removing the `const` this should have not worked before and GCC 14 is more strict here.