### PR TITLE
Only build doc on master branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - documentation
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Just removes an obsolete branch from the list that triggers the documentation CI.