### PR TITLE
Adapt to HPX namespace deprecations

### DIFF
--- a/include/cppuddle/kernel_aggregation/detail/aggregation_executor_pools.hpp
+++ b/include/cppuddle/kernel_aggregation/detail/aggregation_executor_pools.hpp
@@ -57,7 +57,7 @@ public:
     /* const size_t gpu_id = 1; */
     std::lock_guard<aggregation_mutex_t> guard(instance()[gpu_id].pool_mutex);
     assert(!instance()[gpu_id].aggregation_executor_pool.empty());
-    std::optional<hpx::lcos::future<
+    std::optional<hpx::future<
         typename aggregated_executor<Interface>::executor_slice>>
         ret;
     size_t local_id = (instance()[gpu_id].current_interface) %

--- a/include/cppuddle/kernel_aggregation/detail/aggregation_executors_and_allocators.hpp
+++ b/include/cppuddle/kernel_aggregation/detail/aggregation_executors_and_allocators.hpp
@@ -148,7 +148,7 @@ private:
   std::atomic<size_t> slice_counter = 0;
 
   /// Promise to be set when all slices have visited this function call
-  /* hpx::local::promise<void> slices_ready_promise; */
+  /* hpx::promise<void> slices_ready_promise; */
   /// Tracks if all slices have visited this function call
   /* hpx::future<void> all_slices_ready = slices_ready_promise.get_future(); */
   /// How many slices can we expect?
@@ -168,7 +168,7 @@ private:
   aggregation_mutex_t debug_mut;
 #endif
 
-  std::vector<hpx::local::promise<void>> potential_async_promises{};
+  std::vector<hpx::promise<void>> potential_async_promises{};
 
 public:
   aggregated_function_call(const size_t number_slices, bool async_mode, Executor &exec)
@@ -557,10 +557,10 @@ public:
 
   //===============================================================================
 
-  hpx::local::promise<void> slices_full_promise;
+  hpx::promise<void> slices_full_promise;
   /// Promises with the slice executors -- to be set when the starting criteria
   /// is met
-  std::vector<hpx::local::promise<executor_slice>> executor_slices;
+  std::vector<hpx::promise<executor_slice>> executor_slices;
   /// List of aggregated function calls - function will be launched when all
   /// slices have called it
   std::deque<aggregated_function_call<Executor>> function_calls;
@@ -839,14 +839,14 @@ public:
         dealloc_counter = 0;
 
         if (mode == aggregated_executor_modes::STRICT ) {
-          slices_full_promise = hpx::local::promise<void>{};
+          slices_full_promise = hpx::promise<void>{};
         }
       }
 
       // Create Executor Slice future -- that will be returned later
       hpx::future<executor_slice> ret_fut;
       if (local_slice_id < max_slices) {
-        executor_slices.emplace_back(hpx::local::promise<executor_slice>{});
+        executor_slices.emplace_back(hpx::promise<executor_slice>{});
         ret_fut =
             executor_slices[local_slice_id - 1].get_future();
       } else {

--- a/include/cppuddle/kernel_aggregation/detail/aggregation_executors_and_allocators.hpp
+++ b/include/cppuddle/kernel_aggregation/detail/aggregation_executors_and_allocators.hpp
@@ -128,7 +128,7 @@ void exec_post_wrapper(Executor & exec, F &&f, Ts &&...ts) {
 }
 
 template <typename Executor, typename F, typename... Ts>
-hpx::lcos::future<void> exec_async_wrapper(Executor & exec, F &&f, Ts &&...ts) {
+hpx::future<void> exec_async_wrapper(Executor & exec, F &&f, Ts &&...ts) {
   return hpx::async(exec, std::forward<F>(f), std::forward<Ts>(ts)...);
 }
 
@@ -148,9 +148,9 @@ private:
   std::atomic<size_t> slice_counter = 0;
 
   /// Promise to be set when all slices have visited this function call
-  /* hpx::lcos::local::promise<void> slices_ready_promise; */
+  /* hpx::local::promise<void> slices_ready_promise; */
   /// Tracks if all slices have visited this function call
-  /* hpx::lcos::future<void> all_slices_ready = slices_ready_promise.get_future(); */
+  /* hpx::future<void> all_slices_ready = slices_ready_promise.get_future(); */
   /// How many slices can we expect?
   const size_t number_slices;
   const bool async_mode;
@@ -168,7 +168,7 @@ private:
   aggregation_mutex_t debug_mut;
 #endif
 
-  std::vector<hpx::lcos::local::promise<void>> potential_async_promises{};
+  std::vector<hpx::local::promise<void>> potential_async_promises{};
 
 public:
   aggregated_function_call(const size_t number_slices, bool async_mode, Executor &exec)
@@ -182,7 +182,7 @@ public:
     // assert(!all_slices_ready.valid());
   }
   /// Returns true if all required slices have visited this point
-  bool sync_aggregation_slices(hpx::lcos::future<void> &stream_future) {
+  bool sync_aggregation_slices(hpx::future<void> &stream_future) {
     assert(!async_mode);
     assert(potential_async_promises.empty());
     const size_t local_counter = slice_counter++;
@@ -192,7 +192,7 @@ public:
     else return false;
   }
   template <typename F, typename... Ts>
-  void post_when(hpx::lcos::future<void> &stream_future, F &&f, Ts &&...ts) {
+  void post_when(hpx::future<void> &stream_future, F &&f, Ts &&...ts) {
 #if !(defined(NDEBUG)) && defined(DEBUG_AGGREGATION_CALLS)
     // needed for concurrent access to function_tuple and debug_type_information
     // Not required for normal use
@@ -265,7 +265,7 @@ public:
     }
   }
   template <typename F, typename... Ts>
-  hpx::lcos::future<void> async_when(hpx::lcos::future<void> &stream_future,
+  hpx::future<void> async_when(hpx::future<void> &stream_future,
                                      F &&f, Ts &&...ts) {
 #if !(defined(NDEBUG)) && defined(DEBUG_AGGREGATION_CALLS)
     // needed for concurrent access to function_tuple and debug_type_information
@@ -330,7 +330,7 @@ public:
     assert(local_counter < number_slices);
     assert(slice_counter < number_slices + 1);
     assert(potential_async_promises.size() == number_slices);
-    hpx::lcos::future<void> ret_fut =
+    hpx::future<void> ret_fut =
         potential_async_promises[local_counter].get_future();
     if (local_counter == number_slices - 1) {
       /* slices_ready_promise.set_value(); */
@@ -347,7 +347,7 @@ public:
     return ret_fut;
   }
   template <typename F, typename... Ts>
-  hpx::lcos::shared_future<void> wrap_async(hpx::lcos::future<void> &stream_future,
+  hpx::shared_future<void> wrap_async(hpx::future<void> &stream_future,
                                      F &&f, Ts &&...ts) {
     assert(async_mode);
     assert(!potential_async_promises.empty());
@@ -355,7 +355,7 @@ public:
     assert(local_counter < number_slices);
     assert(slice_counter < number_slices + 1);
     assert(potential_async_promises.size() == number_slices);
-    hpx::lcos::shared_future<void> ret_fut =
+    hpx::shared_future<void> ret_fut =
         potential_async_promises[local_counter].get_shared_future();
     if (local_counter == number_slices - 1) {
       auto fut = f(std::forward<Ts>(ts)...);
@@ -496,11 +496,11 @@ public:
       launch_counter++;
     }
     template <typename F, typename... Ts>
-    hpx::lcos::future<void> async(F &&f, Ts &&...ts) {
+    hpx::future<void> async(F &&f, Ts &&...ts) {
       // we should only execute function calls once all slices
       // have been given away (-> Executor Slices start)
       assert(parent.slices_exhausted == true);
-      hpx::lcos::future<void> ret_fut = parent.async(
+      hpx::future<void> ret_fut = parent.async(
           launch_counter, std::forward<F>(f), std::forward<Ts>(ts)...);
       launch_counter++;
       return ret_fut;
@@ -525,11 +525,11 @@ public:
     }
 
     template <typename F, typename... Ts>
-    hpx::lcos::shared_future<void> wrap_async(F &&f, Ts &&...ts) {
+    hpx::shared_future<void> wrap_async(F &&f, Ts &&...ts) {
       // we should only execute function calls once all slices
       // have been given away (-> Executor Slices start)
       assert(parent.slices_exhausted == true);
-      hpx::lcos::shared_future<void> ret_fut = parent.wrap_async(
+      hpx::shared_future<void> ret_fut = parent.wrap_async(
           launch_counter, std::forward<F>(f), std::forward<Ts>(ts)...);
       launch_counter++;
       return ret_fut;
@@ -557,10 +557,10 @@ public:
 
   //===============================================================================
 
-  hpx::lcos::local::promise<void> slices_full_promise;
+  hpx::local::promise<void> slices_full_promise;
   /// Promises with the slice executors -- to be set when the starting criteria
   /// is met
-  std::vector<hpx::lcos::local::promise<executor_slice>> executor_slices;
+  std::vector<hpx::local::promise<executor_slice>> executor_slices;
   /// List of aggregated function calls - function will be launched when all
   /// slices have called it
   std::deque<aggregated_function_call<Executor>> function_calls;
@@ -715,8 +715,8 @@ public:
   //===============================================================================
   // Public Interface
 public:
-  hpx::lcos::future<void> current_continuation;
-  hpx::lcos::future<void> last_stream_launch_done;
+  hpx::future<void> current_continuation;
+  hpx::future<void> last_stream_launch_done;
   std::atomic<size_t> overall_launch_counter = 0;
 
   /// Only meant to be accessed by the slice executors
@@ -764,7 +764,7 @@ public:
 
   /// Only meant to be accessed by the slice executors
   template <typename F, typename... Ts>
-  hpx::lcos::future<void> async(const size_t slice_launch_counter, F &&f,
+  hpx::future<void> async(const size_t slice_launch_counter, F &&f,
                                 Ts &&...ts) {
     std::lock_guard<aggregation_mutex_t> guard(mut);
     assert(slices_exhausted == true);
@@ -785,7 +785,7 @@ public:
   }
   /// Only meant to be accessed by the slice executors
   template <typename F, typename... Ts>
-  hpx::lcos::shared_future<void> wrap_async(const size_t slice_launch_counter, F &&f,
+  hpx::shared_future<void> wrap_async(const size_t slice_launch_counter, F &&f,
                                 Ts &&...ts) {
     std::lock_guard<aggregation_mutex_t> guard(mut);
     assert(slices_exhausted == true);
@@ -810,7 +810,7 @@ public:
     return !slices_exhausted;
   }
 
-  std::optional<hpx::lcos::future<executor_slice>> request_executor_slice() {
+  std::optional<hpx::future<executor_slice>> request_executor_slice() {
     std::lock_guard<aggregation_mutex_t> guard(mut);
     if (!slices_exhausted) {
       const size_t local_slice_id = ++current_slices;
@@ -839,14 +839,14 @@ public:
         dealloc_counter = 0;
 
         if (mode == aggregated_executor_modes::STRICT ) {
-          slices_full_promise = hpx::lcos::local::promise<void>{};
+          slices_full_promise = hpx::local::promise<void>{};
         }
       }
 
       // Create Executor Slice future -- that will be returned later
-      hpx::lcos::future<executor_slice> ret_fut;
+      hpx::future<executor_slice> ret_fut;
       if (local_slice_id < max_slices) {
-        executor_slices.emplace_back(hpx::lcos::local::promise<executor_slice>{});
+        executor_slices.emplace_back(hpx::local::promise<executor_slice>{});
         ret_fut =
             executor_slices[local_slice_id - 1].get_future();
       } else {
@@ -871,7 +871,7 @@ public:
                 gpu_id));
         // Renew promise that all slices will be ready as the primary launch
         // criteria...
-        hpx::lcos::shared_future<void> fut;
+        hpx::shared_future<void> fut;
         if (mode == aggregated_executor_modes::EAGER ||
             mode == aggregated_executor_modes::ENDLESS) {
           // Fallback launch condidtion: Launch as soon as the underlying stream
@@ -922,7 +922,7 @@ public:
       return ret_fut;
     } else {
       // Return empty optional as failure
-      return std::optional<hpx::lcos::future<executor_slice>>{};
+      return std::optional<hpx::future<executor_slice>>{};
     }
   }
   size_t launched_slices;

--- a/tests/work_aggregation_cpu_triad.cpp
+++ b/tests/work_aggregation_cpu_triad.cpp
@@ -36,7 +36,7 @@ void triad_kernel(float_t *A, const float_t *B, const float_t *C, const float_t 
 /// production use!
 struct Dummy_Executor {
   /// Executor is always ready
-  hpx::lcos::future<void> get_future() {
+  hpx::future<void> get_future() {
     // To trigger interruption in exeuctor coalesing manually with the promise
     // For a proper CUDA executor we would get a future that's ready once the
     // stream is ready of course!
@@ -48,7 +48,7 @@ struct Dummy_Executor {
   }
   /// async -- executores immediately and returns ready future
   template <typename F, typename... Ts>
-  hpx::lcos::future<void> async(F &&f, Ts &&...ts) {
+  hpx::future<void> async(F &&f, Ts &&...ts) {
     f(std::forward<Ts>(ts)...);
     return hpx::make_ready_future();
   }
@@ -213,7 +213,7 @@ int hpx_main(int argc, char *argv[]) {
     const float_t scalar = 3.0;
 
     size_t number_tasks = problem_size / kernel_size;
-    std::vector<hpx::lcos::future<void>> futs;
+    std::vector<hpx::future<void>> futs;
 
     for (size_t task_id = 0; task_id < number_tasks; task_id++) {
       // Concurrency Wrapper: Splits stream benchmark into #number_tasks tasks
@@ -222,7 +222,7 @@ int hpx_main(int argc, char *argv[]) {
         if (slice_fut1.has_value()) {
           // Work aggregation Wrapper: Recombines (some) tasks, depending on the
           // number of slices
-          hpx::lcos::future<void> current_fut =
+          hpx::future<void> current_fut =
               slice_fut1.value().then([&, task_id](auto &&fut) {
                 auto slice_exec = fut.get();
 
@@ -258,11 +258,11 @@ int hpx_main(int argc, char *argv[]) {
           return current_fut;
         } else {
           hpx::cout << "ERROR: Executor was not properly initialized!" << std::endl;
-          return hpx::lcos::make_ready_future();
+          return hpx::make_ready_future();
         }
       })); 
     }
-    auto final_fut = hpx::lcos::when_all(futs);
+    auto final_fut = hpx::when_all(futs);
     final_fut.get();
 
     bool results_correct = true;

--- a/tests/work_aggregation_cuda_triad.cpp
+++ b/tests/work_aggregation_cuda_triad.cpp
@@ -183,7 +183,7 @@ int hpx_main(int argc, char *argv[]) {
 
 
       size_t number_tasks = problem_size / kernel_size;
-      std::vector<hpx::lcos::future<void>> futs;
+      std::vector<hpx::future<void>> futs;
       cudaError_t(*func)(void*,const void*,size_t,cudaMemcpyKind,cudaStream_t) = cudaMemcpyAsync;
 
 
@@ -196,7 +196,7 @@ int hpx_main(int argc, char *argv[]) {
           if (slice_fut1.has_value()) {
             // Work aggregation Wrapper: Recombines (some) tasks, depending on the
             // number of slices
-            hpx::lcos::future<void> current_fut =
+            hpx::future<void> current_fut =
                 slice_fut1.value().then([&, task_id](auto &&fut) {
                   auto slice_exec = fut.get();
 
@@ -281,11 +281,11 @@ int hpx_main(int argc, char *argv[]) {
             return current_fut;
           } else {
             hpx::cout << "ERROR: Executor was not properly initialized!" << std::endl;
-            return hpx::lcos::make_ready_future();
+            return hpx::make_ready_future();
           }
         })); 
       }
-      auto final_fut = hpx::lcos::when_all(futs);
+      auto final_fut = hpx::when_all(futs);
       final_fut.get();
       std::chrono::steady_clock::time_point end =
           std::chrono::steady_clock::now();
@@ -353,7 +353,7 @@ int hpx_main(int argc, char *argv[]) {
     for (size_t repetition = 0; repetition < repetitions; repetition++) {
 
       size_t number_tasks = problem_size / kernel_size;
-      std::vector<hpx::lcos::future<void>> futs;
+      std::vector<hpx::future<void>> futs;
       cudaError_t(*func)(void*,const void*,size_t,cudaMemcpyKind,cudaStream_t) = cudaMemcpyAsync;
 
 
@@ -366,7 +366,7 @@ int hpx_main(int argc, char *argv[]) {
           if (slice_fut1.has_value()) {
             // Work aggregation Wrapper: Recombines (some) tasks, depending on the
             // number of slices
-            hpx::lcos::future<void> current_fut =
+            hpx::future<void> current_fut =
                 slice_fut1.value().then([&, task_id](auto &&fut) {
                   auto slice_exec = fut.get();
 
@@ -396,11 +396,11 @@ int hpx_main(int argc, char *argv[]) {
             return hpx::make_ready_future();
           } else {
             hpx::cout << "ERROR: Executor was not properly initialized!" << std::endl;
-            return hpx::lcos::make_ready_future();
+            return hpx::make_ready_future();
           }
         })); 
       }
-      auto final_fut = hpx::lcos::when_all(futs);
+      auto final_fut = hpx::when_all(futs);
       final_fut.get();
     std::chrono::steady_clock::time_point end =
         std::chrono::steady_clock::now();

--- a/tests/work_aggregation_test.cpp
+++ b/tests/work_aggregation_test.cpp
@@ -61,7 +61,7 @@ void add(size_t slice_size, Container &A, Container &B, Container &C) {
 /// production use!
 struct Dummy_Executor {
   /// Executor is always ready
-  hpx::lcos::future<void> get_future() {
+  hpx::future<void> get_future() {
     // To trigger interruption in exeuctor coalesing manually with the promise
     // For a proper CUDA executor we would get a future that's ready once the
     // stream is ready of course!
@@ -73,7 +73,7 @@ struct Dummy_Executor {
   }
   /// async -- executores immediately and returns ready future
   template <typename F, typename... Ts>
-  hpx::lcos::future<void> async(F &&f, Ts &&...ts) {
+  hpx::future<void> async(F &&f, Ts &&...ts) {
     f(std::forward<Ts>(ts)...);
     return hpx::make_ready_future();
   }
@@ -129,7 +129,7 @@ void sequential_test(void) {
   hpx::cout << "Sequential test with all executor slices" << std::endl;
   hpx::cout << "----------------------------------------" << std::endl;
   {
-    std::vector<hpx::lcos::future<void>> slices_done_futs;
+    std::vector<hpx::future<void>> slices_done_futs;
 
     auto slice_fut1 = kernel_pool1::request_executor_slice();
     if (slice_fut1.has_value()) {
@@ -257,7 +257,7 @@ void sequential_test(void) {
     }
     hpx::cout << "Requested all executors!" << std::endl;
     hpx::cout << "Realizing by equesting final fut..." << std::endl;
-    auto final_fut = hpx::lcos::when_all(slices_done_futs);
+    auto final_fut = hpx::when_all(slices_done_futs);
     final_fut.get();
   }
   hpx::cout << std::endl;
@@ -270,7 +270,7 @@ void interruption_test(void) {
   {
     cppuddle::kernel_aggregation::aggregated_executor<Dummy_Executor> agg_exec{
         4, cppuddle::kernel_aggregation::aggregated_executor_modes::EAGER};
-    std::vector<hpx::lcos::future<void>> slices_done_futs;
+    std::vector<hpx::future<void>> slices_done_futs;
 
     auto slice_fut1 = agg_exec.request_executor_slice();
     if (slice_fut1.has_value()) {
@@ -320,7 +320,7 @@ void interruption_test(void) {
     hpx::cout << "Requested 1 executors!" << std::endl;
     hpx::cout << "Realizing by setting the continuation future..." << std::endl;
     // Interrupt - should cause executor to start executing all slices
-    auto final_fut = hpx::lcos::when_all(slices_done_futs);
+    auto final_fut = hpx::when_all(slices_done_futs);
     final_fut.get();
   }
   hpx::cout << std::endl;
@@ -339,7 +339,7 @@ void failure_test(bool type_error) {
 
     auto slice_fut1 = agg_exec.request_executor_slice();
 
-    std::vector<hpx::lcos::future<void>> slices_done_futs;
+    std::vector<hpx::future<void>> slices_done_futs;
     if (slice_fut1.has_value()) {
     slices_done_futs.emplace_back(slice_fut1.value().then([](auto &&fut) {
       auto slice_exec = fut.get();
@@ -401,7 +401,7 @@ void failure_test(bool type_error) {
 
     hpx::cout << "Requested all executors!" << std::endl;
     hpx::cout << "Realizing by equesting final fut..." << std::endl;
-    auto final_fut = hpx::lcos::when_all(slices_done_futs);
+    auto final_fut = hpx::when_all(slices_done_futs);
     final_fut.get();
   }
   hpx::cout << std::endl;
@@ -420,7 +420,7 @@ void pointer_add_test(void) {
       8, 2, cppuddle::kernel_aggregation::aggregated_executor_modes::STRICT);
   {
     std::vector<float> erg(512);
-    std::vector<hpx::lcos::future<void>> slices_done_futs;
+    std::vector<hpx::future<void>> slices_done_futs;
 
     auto slice_fut1 = kernel_pool2::request_executor_slice();
 
@@ -585,7 +585,7 @@ void pointer_add_test(void) {
     }
     hpx::cout << "Requested all executors!" << std::endl;
     hpx::cout << "Realizing by requesting final fut..." << std::endl;
-    auto final_fut = hpx::lcos::when_all(slices_done_futs);
+    auto final_fut = hpx::when_all(slices_done_futs);
     final_fut.get();
 
     hpx::cout << "Number add_pointer_launches=" << add_pointer_launches
@@ -619,7 +619,7 @@ void references_add_test(void) {
                 cppuddle::kernel_aggregation::aggregated_executor<
                     Dummy_Executor>>>(0));
     std::vector<float> erg(512);
-    std::vector<hpx::lcos::future<void>> slices_done_futs;
+    std::vector<hpx::future<void>> slices_done_futs;
 
     auto slice_fut1 = agg_exec.request_executor_slice();
     if (slice_fut1.has_value()) {
@@ -763,7 +763,7 @@ void references_add_test(void) {
     }
     hpx::cout << "Requested all executors!" << std::endl;
     hpx::cout << "Realizing by requesting final fut..." << std::endl;
-    auto final_fut = hpx::lcos::when_all(slices_done_futs);
+    auto final_fut = hpx::when_all(slices_done_futs);
     final_fut.get();
     hpx::cout << "Number add_launches=" << add_launches
               << std::endl;


### PR DESCRIPTION
This PR changes the ```hpx::lcos::``` and the ```hpx::local::``` namespaces to ```hpx::```, allowing builds with the current HPX master branch.